### PR TITLE
Fix #90 by removing indentation in ls -l

### DIFF
--- a/design/cmd/ls.toml
+++ b/design/cmd/ls.toml
@@ -5,7 +5,7 @@ Specifications for the artifact cmdline interface
 
 [SPC-cmd-ls]
 text = '''
-The `art ls` command shall be used to list information the artifacts in a 
+The `art ls` command shall be used to list information the artifacts in a
 project.
 
 `ls` is the primary window into a user's artifacts, creating a simple
@@ -40,8 +40,8 @@ The following **will** be followed:
 - names that are very litle or not complete will be red
 - names that are in ERROR will *blink bold red*
 
-For completed, the levels are: (100%, 70%, 40%, 0%) which correspond to points (3, 2, 1, 0)
-and colors (blue, yellow, yellow, red)
+For completed, the levels are: (100%, 70%, 40%, 0%) which correspond to points
+(3, 2, 1, 0) and colors (blue, yellow, yellow, red)
 
 For tested, the levels are: (100%, 50%, 0%) which correspond to points (2, 1, 0)
 and colors (blue, yellow, red)
@@ -60,9 +60,9 @@ The following flags are used to specify what to display:
 - D: display the path to where the artifact is defined
 - P: display parts names in reduced form
 - O: display partof names in reduced form
-- T: display the text formatted as markdown. If `-l` is not specified,
-this will display the first 30 chars of the "debug" representation
-of the text
+- T: display the text formatted as markdown. If `-l` is not specified, this
+  will display up to 50 chars of the first line of the text, truncating it
+  with ... if necessary.
 - L: display the loc path (implementation path)
 '''
 
@@ -96,4 +96,5 @@ Tests for ls are relatively straightforward and mostly involve:
 - having an example project
 - running the ls command with various different parameters
 - validating the output looks as expected
+- checking that long and multi-line text is split up as it should be
 '''

--- a/src/cmd/display.rs
+++ b/src/cmd/display.rs
@@ -204,10 +204,9 @@ impl FmtArtifact {
         // format the text
         // TODO: use markdown to apply styles to the text
         if let Some(ref text) = self.text {
-            self.write_start(w, "\n * text:\n    ", color);
-            let lines: Vec<_> = text.split('\n').collect();
-            let text = lines.join("\n    ");
-            w.write_all(text.as_ref()).unwrap();
+            self.write_start(w, "\n * text:\n", color);
+            w.write_all(text.trim_right().as_ref()).unwrap();
+            w.write_all("\n".as_ref()).unwrap();
         }
 
         try!(w.write_all("\n".as_ref()));

--- a/src/cmd/display.rs
+++ b/src/cmd/display.rs
@@ -206,7 +206,9 @@ impl FmtArtifact {
         if let Some(ref text) = self.text {
             self.write_start(w, "\n * text:\n", color);
             w.write_all(text.trim_right().as_ref()).unwrap();
-            w.write_all("\n".as_ref()).unwrap();
+            if self.long {
+                w.write_all("\n".as_ref()).unwrap();
+            }
         }
 
         try!(w.write_all("\n".as_ref()));

--- a/src/cmd/tests/test_ls.rs
+++ b/src/cmd/tests/test_ls.rs
@@ -110,6 +110,37 @@ PARTS                      | PARTOF     | IMPLEMENTED     | DEFINED             
 #[cfg(windows)]
 const LS_S_C_STAR_FOO: &'static [u8] = LS_S_C_STAR_FOO_NO_COL;
 
+#[cfg(not(windows))]
+const LS_T_LONG: &'static [u8] = b"\x1b[1m|  | DONE TEST | NAME            | \
+ TEXT\n\x1b[0m|\x1b[1;31m-\x1b[0m\x1b[1;31m-\x1b[0m|   \x1b[1;31m0\x1b[0m%   \
+ \x1b[1;31m0\x1b[0m% | \x1b[1;4;31mTST-line-long\x1b[0m   | \
+ This line is very very very very long and it sh...\n";
+
+#[cfg(windows)]
+const LS_T_LONG: &'static [u8] = b"|  | DONE TEST | NAME            | TEXT\n\
+|--|   0%   0% | TST-line-long   | This line is very very very very long and it sh...";
+
+#[cfg(not(windows))]
+const LS_T_MULTI: &'static [u8] = b"\x1b[1m|  | DONE TEST | NAME             | \
+TEXT\n\x1b[0m|\x1b[1;31m-\x1b[0m\x1b[1;31m-\x1b[0m|   \x1b[1;31m0\x1b[0m%   \
+\x1b[1;31m0\x1b[0m% | \x1b[1;4;31mTST-line-multi\x1b[0m   | \
+This text has multiple lines.\n";
+
+#[cfg(windows)]
+const LS_T_MULTI: &'static [u8] = b"|  | DONE TEST | NAME             | TEXT\n\
+|--|   0%   0% | TST-line-multi   | This text has multiple lines.";
+
+#[cfg(not(windows))]
+const LS_L_MULTI: &'static [u8] = b"|\x1b[1;31m-\x1b[0m\x1b[1;31m-\x1b[0m|   \
+\x1b[1;31m0\x1b[0m%   \x1b[1;31m0\x1b[0m% | \x1b[1;4;31mTST-line-multi\x1b[0m \
+\x1b[32m\n * text:\n\x1b[0mThis text has multiple lines.\nThis is the second one.\n\
+You shouldn't see these later lines!\n\n";
+
+#[cfg(windows)]
+const LS_L_MULTI: &'static [u8] = b"|--|   0%   0% | TST-line-multi \n\
+ * text:\nThis text has multiple lines.\nThis is the second one.\n\
+You shouldn't see these later lines!\n\n";
+
 const LS_FILTER: &'static [u8] =
     b"|  | DONE TEST | NAME     | PARTS   \n|DT| 100% 100% | TST-foo  | \n";
 
@@ -153,6 +184,14 @@ text = 'tst for foo'
 [TST-foo_bar]
 partof = 'SPC-foo'
 text = 'tst for foo_bar'
+[TST-line-long]
+text = 'This line is very very very very long and it should probably get trimmed down.'
+[TST-line-multi]
+text = '''
+This text has multiple lines.
+This is the second one.
+You shouldn't see these later lines!
+'''
 
 [SPC-unresolvable]
 partof = 'SPC-unresolvable-1-1'
@@ -188,7 +227,7 @@ partof = 'REQ-dne'
     fn debug_bytes(result: &[u8], expected: &[u8]) {
         // sleep for a bit so stderr passes us
         thread::sleep(time::Duration::new(0, 2e8 as u32));
-        println!("Debug Result:");
+        println!("\nDebug Result:");
         for b in result {
             print!("{}", *b as char);
         }
@@ -204,8 +243,7 @@ partof = 'REQ-dne'
         println!("Repr Expected:");
         repr_bytes(expected);
         println!("");
-        println!("--Expected Repr DONE");
-
+        println!("--Expected Repr DONE\n");
     }
 
     let dne_locs: HashMap<_, _> = HashMap::from_iter(vec![(Name::from_str("SPC-dne").unwrap(),
@@ -240,10 +278,37 @@ partof = 'REQ-dne'
     assert!(ls::run_cmd(&mut w, &cwd, &cmd, &project).is_err());
     assert_eq!(vb(b""), w);
 
+    // Test that if the first line is too long that it's trimmed
+    w.clear();
+    cmd.pattern = "TST-line-long".to_string();
+    cmd.fmt_settings.color = COLOR_IF_POSSIBLE;
+    cmd.fmt_settings.text = true;
+    ls::run_cmd(&mut w, &cwd, &cmd, &project).unwrap();
+    // debug_bytes(&w, LS_T_LONG);
+    assert_eq!(vb(LS_T_LONG), w);
+
+    // Test that only the first line is selected
+    w.clear();
+    cmd.pattern = "TST-line-multi".to_string();
+    cmd.fmt_settings.text = true;
+    ls::run_cmd(&mut w, &cwd, &cmd, &project).unwrap();
+    // debug_bytes(&w, LS_T_MULTI);
+    assert_eq!(vb(LS_T_MULTI), w);
+
+    // Test that -l output looks correct
+    w.clear();
+    cmd.pattern = "TST-line-multi".to_string();
+    cmd.fmt_settings.text = true;
+    cmd.fmt_settings.long = true;
+    ls::run_cmd(&mut w, &cwd, &cmd, &project).unwrap();
+    // debug_bytes(&w, LS_L_MULTI);
+    assert_eq!(vb(LS_L_MULTI), w);
+
     // ls all fields
     // do a search in only parts using regex s.c
     w.clear();
     cmd.pattern = "s.c.*foo".to_string();
+    cmd.fmt_settings.long = false;
     cmd.fmt_settings.color = COLOR_IF_POSSIBLE;
     cmd.fmt_settings.path = true;
     cmd.fmt_settings.parts = true;

--- a/src/cmd/tests/test_ls.rs
+++ b/src/cmd/tests/test_ls.rs
@@ -84,8 +84,8 @@ const LS_REQ_FOO: &'static [u8] = LS_REQ_FOO_NO_COL;
 const LS_S_C_STAR_FOO_NO_COL: &'static [u8] = b"|  | DONE TEST | NAME     | \
 PARTS                      | PARTOF     | IMPLEMENTED     | DEFINED              | TEXT\n|D-| \
 100%  50% | REQ-foo  | SPC-foo                    | REQ        |                 | ../../reqs/foo.\
-toml  | req for foo \n|--|  -1%  -1% | SPC      | SPC-foo, SPC-unresolvable  |            \
-|                 | PARENT               | AUTO \n";
+toml  | req for foo\n|--|  -1%  -1% | SPC      | SPC-foo, SPC-unresolvable  |            \
+|                 | PARENT               | AUTO\n";
 
 
 
@@ -93,8 +93,8 @@ toml  | req for foo \n|--|  -1%  -1% | SPC      | SPC-foo, SPC-unresolvable  |  
 const LS_S_C_STAR_FOO_NO_COL: &'static [u8] = b"|  | DONE TEST | NAME     | \
 PARTS                      | PARTOF     | IMPLEMENTED     | DEFINED              | TEXT\n|D-| \
 100%  50% | REQ-foo  | SPC-foo                    | REQ        |                 | \
-..\\..\\reqs\\foo.toml  | req for foo \n|--|  -1%  -1% | SPC      | SPC-foo, SPC-unresolvable  \
-|            |                 | PARENT               | AUTO \n";
+..\\..\\reqs\\foo.toml  | req for foo\n|--|  -1%  -1% | SPC      | SPC-foo, SPC-unresolvable  \
+|            |                 | PARENT               | AUTO\n";
 
 
 #[cfg(not(windows))]
@@ -102,10 +102,10 @@ const LS_S_C_STAR_FOO: &'static [u8] = b"\x1b[1m|  | DONE TEST | NAME      | \
 PARTS                      | PARTOF     | IMPLEMENTED     | DEFINED              | TEXT\n\x1b\
 [0m|\x1b[1;34mD\x1b[0m\x1b[1;33m-\x1b[0m| \x1b[1;34m100\x1b[0m%  \x1b[1;33m50\x1b[0m% | \x1b\
 [1;4;34mREQ-foo\x1b[0m   | \x1b[34mSPC-foo\x1b[0m                    | \x1b[33mREQ\x1b[0m        \
-| \x1b[32m\x1b[0m                | ../../reqs/foo.toml  | req for foo \n|\x1b[1;5;31m!\x1b[0m\x1b\
+| \x1b[32m\x1b[0m                | ../../reqs/foo.toml  | req for foo\n|\x1b[1;5;31m!\x1b[0m\x1b\
 [1;5;31m!\x1b[0m|  \x1b[1;5;31m-1\x1b[0m%  \x1b[1;5;31m-1\x1b[0m% | \x1b[1;4;31mSPC\x1b[0m       \
 | \x1b[34mSPC-foo\x1b[0m, \x1b[31mSPC-unresolvable\x1b[0m  |            | \x1b[32m\x1b\
-[0m                | PARENT               | AUTO \n";
+[0m                | PARENT               | AUTO\n";
 
 #[cfg(windows)]
 const LS_S_C_STAR_FOO: &'static [u8] = LS_S_C_STAR_FOO_NO_COL;

--- a/src/ui/fmt.rs
+++ b/src/ui/fmt.rs
@@ -60,14 +60,25 @@ pub fn fmt_artifact(name: &NameRc,
             out.text = Some(artifact.text.clone());
         } else {
             // return only the first "line" according to markdown
-            let mut s = String::new();
-            for l in artifact.text.lines() {
-                let l = l.trim();
-                if l == "" {
-                    break;
-                }
-                s.write_str(l).unwrap();
-                s.push(' ');
+            let mut end = artifact.text.find('\n').unwrap_or(artifact.text.len());
+            // TODO: Calculate Unicode width?
+            const MAX_LINE_LEN: usize = 50;
+            let should_add_ellipsis: bool;
+            if end > MAX_LINE_LEN {
+                should_add_ellipsis = true;
+                // Allow space for '...'
+                end = MAX_LINE_LEN - 3;
+            } else {
+                should_add_ellipsis = false;
+            }
+            // Find a Unicode-safe place to split
+            // TODO: Split at a grapheme cluster?
+            while !artifact.text.is_char_boundary(end) {
+                end -= 1;
+            }
+            let mut s = artifact.text[..end].into();
+            if should_add_ellipsis {
+                s += "...";
             }
             out.text = Some(s);
         }


### PR DESCRIPTION
Since ls -l indented the text section by 4 characters, requirements
written 80 characters wide sometimes exhibited ugly wrapping. By
removing the indentation, 80 character wide messages look good.

This also adds an extra newline at the end of the ls -l text section in
order to more easily distinguish between each entry.