### PR TITLE
Add --output-directory flag for export subcommand

### DIFF
--- a/design/cmd/other.toml
+++ b/design/cmd/other.toml
@@ -4,11 +4,17 @@ text = '''
 formats. This will allow a user to display their artifacts in a pretty
 format on services like github.
 
-Syntax: `art export TYPE`
+Syntax: `art export [-d|--output-directory PATH] TYPE`
 
 Supported types **shall** be:
 - html: this is the MUST HAVE export type
 - markdown: this is a possible future type
+
+`art export` **shall** provide a flag `-d|--output-directory` that allows
+the user to specify a different output directory for the exported files.
+This flag is followed by a (possibly non-existent) path `PATH`.
+When the `-d|--output-directory` flag is ommitted, the path `PATH` defaults
+to the current working directory `cwd`.
 '''
 
 [SPC-cmd-fmt]


### PR DESCRIPTION
I made an extra flag in the `export` subcommand: `-d` or `--output-directory` (which expects a parameter, a PATH). `export` will then output its contents into that directory, instead of in the `cwd`.

Closes #98 