### PR TITLE
Added serde feature for chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.6.5"
 
 [dependencies]
 ansi_term = "0.7"
-chrono = "0.3.0"
 difference = "1.0"
 fern = "0.3.5"
 itertools = "0.5"
@@ -29,6 +28,10 @@ time = "0.1"
 toml = "0.2"
 unicode-segmentation = "1.1.0"
 unicode-width = "0.1.4"
+
+[dependencies.chrono]
+features = ["serde"]
+version = "0.3"
 
 [dependencies.clap]
 default-features = false


### PR DESCRIPTION
chrono::DateTime is now (de)serializable. This will allow diesel to translate the field directly to and from pgSQL database.