### PR TITLE
Added TestRunSearch struct to hold any possible way of searching test runs

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -47,6 +47,21 @@ pub struct NewTestRun {
 	pub data: Option<Vec<u8>>,
 }
 
+// Holds any possible way to search for test runs
+// Used to return all test runs that match the non-`none` fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestRunSearch {
+	pub test_name: Option<String>,
+	pub passed: Option<bool>,
+	pub artifacts: Option<Vec<String>>,
+	pub epoch: Option<f32>,
+	pub version_id: Option<i32>,
+	pub major: Option<String>,
+	pub minor: Option<String>,
+	pub patch: Option<String>,
+	pub build: Option<String>,
+}
+
 table! {
 	test_name (name) {
 		name -> Text,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -22,8 +22,7 @@ pub struct Version {
 	pub build: Option<String>,
 }
 
-#[derive(Queryable)]
-#[table_name="version"]
+#[derive(Debug, Queryable, Serialize, Deserialize)]
 pub struct NewVersion {
 	pub major: String,
 	pub minor: Option<String>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -22,6 +22,15 @@ pub struct Version {
 	pub build: Option<String>,
 }
 
+#[derive(Queryable)]
+#[table_name="version"]
+pub struct NewVersion {
+	pub major: String,
+	pub minor: Option<String>,
+	pub patch: Option<String>,
+	pub build: Option<String>,
+}
+
 #[derive(Debug, Queryable, Insertable, Serialize, Deserialize)]
 #[table_name="test_run"]
 pub struct TestRun {
@@ -47,19 +56,15 @@ pub struct NewTestRun {
 	pub data: Option<Vec<u8>>,
 }
 
+
+
 // Holds any possible way to search for test runs
 // Used to return all test runs that match the non-`none` fields
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestRunSearch {
-	pub test_name: Option<String>,
-	pub passed: Option<bool>,
-	pub artifacts: Option<Vec<String>>,
-	pub epoch: Option<f32>,
-	pub version_id: Option<i32>,
-	pub major: Option<String>,
-	pub minor: Option<String>,
-	pub patch: Option<String>,
-	pub build: Option<String>,
+	pub min_epoch: Option<f32>,
+	pub max_epoch: Option<f32>,
+	pub versions: Option<Vec<NewVersion>>,
 }
 
 table! {


### PR DESCRIPTION
The goal of this struct is that it can hold any possible combination of search parameters for searching the test run database. A search should deserialize the parameters into this struct, then search the database by any field that is `Some`, ignoring all `None` fields. 