### PR TITLE
Implements 'GetRuns' API call

### DIFF
--- a/scripts/GetRuns.py
+++ b/scripts/GetRuns.py
@@ -1,0 +1,49 @@
+"""
+Before running server:
+    
+    run `echo DATABASE_URL=postgres://username:password@localhost/artifact > .env' 
+        to create .env file in /artifact directory
+    (the database name might be changeable, as long as it is specified in the .env)
+
+Run the artifact server with:
+    cargo run --features server -- -v serve
+
+Then in a separate shell run this script to interact with it by calling:
+    python2 scripts/api.py
+
+This script may grow in the future.
+"""
+
+from __future__ import print_function
+
+import json
+import pprint
+import requests
+import argparse
+
+
+parser = argparse.ArgumentParser(description='run against artifact JSON-RPC')
+parser.add_argument('addr', help='address of artifact server')
+parser.add_argument('method', help='method to use. Default=GetArtifacts',
+                    default='GetAllTestRuns', nargs='?')
+
+args = parser.parse_args()
+addr = args.addr + '/json-rpc'
+
+payload = { 
+    'jsonrpc': '2.0',
+    'id': 1,
+    'method': 'GetRuns',
+    'params': {'min_epoch': '6', 'max_epoch': '999', 'versions': [
+                        {'major': '2', 'minor': '7', 'patch': '6' },
+                        {'major': '6', 'build': '4323'}]}
+}
+
+print("calling with addr={}, payload={}".format(addr, payload))
+response = requests.get(addr, data=json.dumps(payload))
+try:
+    print('json response:')
+    pprint.pprint(response.json())
+except:
+    print('Got error:\n')
+    print(response.text)

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -54,6 +54,17 @@ impl RpcMethodSync for GetTests {
     }
 }
 
+/// `GetRuns` API Handler
+struct GetRuns;
+impl RpcMethodSync for GetRuns {
+	fn call(&self, params: Params) -> result::Result<serde_json::Value, RpcEror> {
+		info!("GetRuns called");
+		let connection = establish_connection();
+		
+		
+	}
+}
+
 /// `GetAllTestRuns` API handler
 struct GetAllTestRuns;
 impl RpcMethodSync for GetAllTestRuns {

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -95,7 +95,7 @@ impl RpcMethodSync for GetRuns {
 				query = query.filter(test_run::version_id.eq_any(version_ids));
 			}
 			
-			let mut finalresult: Vec<TestRun> = Vec::new();
+			//let mut finalresult: Vec<TestRun> = Vec::new();
 			
 			if let Some(min_epoch) = test_run_search.min_epoch {
 				query = query.filter(test_run::epoch.ge(min_epoch));
@@ -104,7 +104,7 @@ impl RpcMethodSync for GetRuns {
 				query = query.filter(test_run::epoch.le(max_epoch));
 			}
 			
-			let finalresult = extend(query.load::<TestRun>(&connection).unwrap());
+			let finalresult = query.load::<TestRun>(&connection).unwrap();
 				
 	
 			Ok(serde_json::to_value(finalresult).unwrap())

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -7,6 +7,7 @@ use serde_json;
 use diesel::prelude::*;
 use api::establish_connection;
 use api::types::*;
+use api::utils;
 use export::ArtifactData;
 
 use super::ARTIFACTS;
@@ -61,7 +62,10 @@ impl RpcMethodSync for GetRuns {
 		info!("GetRuns called");
 		let connection = establish_connection();
 		
+		let val = serde_json::to_value(params);
+		info!("{:?}", val);
 		
+		return Err(utils::invalid_params("applesauce"));
 	}
 }
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -47,6 +47,21 @@ pub struct NewTestRun {
 	pub data: Option<Vec<u8>>,
 }
 
+// Holds any possible way to search for test runs
+// Used to return all test runs that match the non-`none` fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestRunSearch {
+	pub test_name: Option<String>,
+	pub passed: Option<bool>,
+	pub artifacts: Option<Vec<String>>,
+	pub epoch: Option<f32>,
+	pub version_id: Option<i32>,
+	pub major: Option<String>,
+	pub minor: Option<String>,
+	pub patch: Option<String>,
+	pub build: Option<String>,
+}
+
 table! {
 	test_name (name) {
 		name -> Text,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -22,6 +22,15 @@ pub struct Version {
 	pub build: Option<String>,
 }
 
+#[derive(Queryable)]
+#[table_name="version"]
+pub struct NewVersion {
+	pub major: String,
+	pub minor: Option<String>,
+	pub patch: Option<String>,
+	pub build: Option<String>,
+}
+
 #[derive(Debug, Queryable, Insertable, Serialize, Deserialize)]
 #[table_name="test_run"]
 pub struct TestRun {
@@ -47,19 +56,15 @@ pub struct NewTestRun {
 	pub data: Option<Vec<u8>>,
 }
 
+
+
 // Holds any possible way to search for test runs
 // Used to return all test runs that match the non-`none` fields
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestRunSearch {
-	pub test_name: Option<String>,
-	pub passed: Option<bool>,
-	pub artifacts: Option<Vec<String>>,
-	pub epoch: Option<f32>,
-	pub version_id: Option<i32>,
-	pub major: Option<String>,
-	pub minor: Option<String>,
-	pub patch: Option<String>,
-	pub build: Option<String>,
+	pub min_epoch: Option<f32>,
+	pub max_epoch: Option<f32>,
+	pub versions: Option<Vec<NewVersion>>,
 }
 
 table! {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -22,7 +22,7 @@ pub struct Version {
 	pub build: Option<String>,
 }
 
-#[derive(Queryable)]
+#[derive(Debug, Queryable, Serialize, Deserialize)]
 pub struct NewVersion {
 	pub major: String,
 	pub minor: Option<String>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -12,7 +12,7 @@ pub struct ArtifactName {
 	pub name: String,
 }
 
-#[derive(Queryable, Insertable)]
+#[derive(Debug, Queryable, Insertable)]
 #[table_name="version"]
 pub struct Version {
 	pub id: i32,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -12,7 +12,7 @@ pub struct ArtifactName {
 	pub name: String,
 }
 
-#[derive(Debug, Queryable, Insertable)]
+#[derive(Debug, Queryable, Insertable, Serialize)]
 #[table_name="version"]
 pub struct Version {
 	pub id: i32,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -23,7 +23,6 @@ pub struct Version {
 }
 
 #[derive(Queryable)]
-#[table_name="version"]
 pub struct NewVersion {
 	pub major: String,
 	pub minor: Option<String>,


### PR DESCRIPTION
Searches and returns test runs based on min/max epoch, and/or a list of versions.
To get all test runs, call with `'min_epoch': 0`
We can probably delete GetAllTestRuns because this now includes that functionality.