### PR TITLE
Add ability to generate unix shell completions

### DIFF
--- a/src/cmd/completions.rs
+++ b/src/cmd/completions.rs
@@ -21,8 +21,10 @@ pub fn get_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("completions")
         .settings(&SUBCMD_SETTINGS)
         .about("Generates completion scripts for your shell")
-        .arg(Arg::with_name("SHELL")
-             .required(true)
-             .possible_values(&["bash", "fish", "zsh"])
-             .help("The shell to generate the script for"))
+        .arg(
+            Arg::with_name("SHELL")
+                .required(true)
+                .possible_values(&["bash", "fish", "zsh"])
+                .help("The shell to generate the script for"),
+        )
 }

--- a/src/cmd/completions.rs
+++ b/src/cmd/completions.rs
@@ -1,0 +1,28 @@
+/*  artifact: the requirements tracking tool made for developers
+ * Copyright (C) 2017  Garrett Berg <@vitiral, vitiral@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Lesser GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the Lesser GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * */
+
+use super::types::*;
+
+pub fn get_subcommand<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("completions")
+        .settings(&SUBCMD_SETTINGS)
+        .about("Generates completion scripts for your shell")
+        .arg(Arg::with_name("SHELL")
+             .required(true)
+             .possible_values(&["bash", "fish", "zsh"])
+             .help("The shell to generate the script for"))
+}

--- a/src/cmd/matches.rs
+++ b/src/cmd/matches.rs
@@ -24,12 +24,9 @@ use super::ls;
 use super::check;
 use super::fmt as fmtcmd;
 use super::update;
+use super::completions;
 
-pub fn get_matches<'a, I, T>(args: I) -> ClapResult<ArgMatches<'a>>
-where
-    I: IntoIterator<Item = T>,
-    T: Into<OsString> + clone::Clone,
-{
+pub fn art_app<'a, 'b>() -> App<'a, 'b> {
     let app = App::new("artifact")
         .version(env!("CARGO_PKG_VERSION"))
         .about(
@@ -66,9 +63,18 @@ where
         .subcommand(check::get_subcommand())
         .subcommand(fmtcmd::get_subcommand())
         .subcommand(export::get_subcommand())
-        .subcommand(update::get_subcommand());
+        .subcommand(update::get_subcommand())
+        .subcommand(completions::get_subcommand());
 
-    let app = add_serve_cmd(app);
+    add_serve_cmd(app)
+}
+
+pub fn get_matches<'a, I, T>(args: I) -> ClapResult<ArgMatches<'a>>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + clone::Clone,
+{
+    let app = art_app();
     app.get_matches_from_safe(args)
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -29,7 +29,7 @@ use user;
 use utils;
 use security;
 
-use clap::{ArgMatches, ErrorKind as ClEk};
+use clap::{ArgMatches, ErrorKind as ClEk, Shell};
 use ansi_term::Colour::Green;
 
 mod export;
@@ -42,6 +42,7 @@ mod fmt;
 mod init;
 mod tutorial;
 mod update;
+mod completions;
 
 #[cfg(feature = "server")]
 mod server;
@@ -132,6 +133,22 @@ where
         info!("Calling the tutorial command");
         let c = tutorial::get_cmd(t)?;
         tutorial::run_cmd(&work_tree, c).unwrap();
+        return Ok(0);
+    }
+
+    // If completions is selected, generate them for the shell.
+    if let Some(t) = matches.subcommand_matches("completions") {
+        let shell = t
+            .value_of("SHELL")
+            .expect("clap parsed arguments incorrectly!");
+        info!("Generating completions for shell: {}", shell);
+        let shell = match shell {
+            "bash" => Shell::Bash,
+            "fish" => Shell::Fish,
+            "zsh" => Shell::Zsh,
+            _ => panic!("clap parsed arguments incorrectly!")
+        };
+        matches::art_app().gen_completions_to("art", shell, w);
         return Ok(0);
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -138,15 +138,14 @@ where
 
     // If completions is selected, generate them for the shell.
     if let Some(t) = matches.subcommand_matches("completions") {
-        let shell = t
-            .value_of("SHELL")
+        let shell = t.value_of("SHELL")
             .expect("clap parsed arguments incorrectly!");
         info!("Generating completions for shell: {}", shell);
         let shell = match shell {
             "bash" => Shell::Bash,
             "fish" => Shell::Fish,
             "zsh" => Shell::Zsh,
-            _ => panic!("clap parsed arguments incorrectly!")
+            _ => panic!("clap parsed arguments incorrectly!"),
         };
         matches::art_app().gen_completions_to("art", shell, w);
         return Ok(0);


### PR DESCRIPTION
This is a complete implementation of what is essentially a feature request, so I opened this PR rather than an issue.

Add `completions` subcommand that accepts one of `bash`, `fish`, or `zsh` and then dumps the relevant completion files to the `io::Write` passed to `cmd::cmd`, which in the app is standard output where it can then be redirected to a file.