### PR TITLE
Add a bunch of flags to control parsing, formatting and exporting.

### DIFF
--- a/.art/settings.toml
+++ b/.art/settings.toml
@@ -17,7 +17,11 @@ exclude_code_paths = [
 
 code_url = "https://github.com/vitiral/artifact/blob/master/{file}#L{line}"
 
+[parse]
+md_name_start = "#"
+
 [export]
+md_name_start = "#"
 md_header = """
 Artifact design docs, exported to markdown.
 

--- a/artifact-app/src/export.rs
+++ b/artifact-app/src/export.rs
@@ -79,6 +79,7 @@ fn export_markdown(cmd: &Export, project_ser: ProjectSer) -> io::Result<()> {
         code_url: project_ser.settings.code_url.clone(),
         family: project_ser.settings.export.md_family.clone(),
         dot: project_ser.settings.export.md_dot.clone(),
+        name_prefix: project_ser.settings.export.md_name.to_prefix_string(),
     };
     let md = SerMarkdown::with_settings(&project_ser, settings);
 

--- a/artifact-app/tests/data_interop.rs
+++ b/artifact-app/tests/data_interop.rs
@@ -101,6 +101,11 @@ fn data_interop_basic() {
 }
 
 #[test]
+fn data_interop_settings() {
+    run_interop_tests(INTEROP_TESTS_PATH.join("settings"));
+}
+
+#[test]
 /// #TST-read-artifact.lints
 fn data_interop_lints_error1() {
     run_interop_tests(INTEROP_TESTS_PATH.join("lints"));

--- a/artifact-data/src/settings.rs
+++ b/artifact-data/src/settings.rs
@@ -33,6 +33,10 @@ pub(crate) struct SettingsRaw {
     pub code_url: Option<String>,
 
     #[serde(default)]
+    pub parse: SettingsParse,
+    #[serde(default)]
+    pub format: SettingsFormat,
+    #[serde(default)]
     pub export: SettingsExport,
 }
 
@@ -158,7 +162,7 @@ pub(crate) fn load_settings<P: AsRef<Path>>(
     };
 
     let (send_lints, recv_lints) = ::std::sync::mpsc::channel();
-    let paths = Settings {
+    let settings = Settings {
         base: project_path.clone(),
         settings_path: settings_path,
         code_paths: resolve_raw_paths(&send_lints, &project_path, &raw.code_paths),
@@ -171,11 +175,14 @@ pub(crate) fn load_settings<P: AsRef<Path>>(
         ),
         code_url: raw.code_url,
 
+        parse: raw.parse,
+        format: raw.format,
         export: raw.export,
     };
+
     drop(send_lints);
     let lints = recv_lints.into_iter().collect();
-    (lints, Some(paths))
+    (lints, Some(settings))
 }
 
 /// Load a list of string paths using the `project_path` as the base path (i.e. from a settings file)

--- a/artifact-frontend/src/view.rs
+++ b/artifact-frontend/src/view.rs
@@ -88,6 +88,7 @@ pub(crate) fn ser_markdown(model: &Model) -> artifact_ser::markdown::SerMarkdown
         code_url: model.shared.settings.code_url.clone(),
         family: SettingsMdFamily::Dot,
         dot: SettingsMdDot::Ignore,
+        name_prefix: "".to_string(),
     };
 
     SerMarkdown::with_settings(&model.shared, settings)

--- a/artifact-lib/src/expected.rs
+++ b/artifact-lib/src/expected.rs
@@ -64,6 +64,10 @@ pub struct SettingsAssert {
     pub code_url: Option<String>,
 
     #[serde(default)]
+    pub parse: SettingsParse,
+    #[serde(default)]
+    pub format: SettingsFormat,
+    #[serde(default)]
     pub export: SettingsExport,
 }
 
@@ -157,6 +161,8 @@ impl SettingsAssert {
             exclude_artifact_paths: prefix_paths(base, &self.exclude_artifact_paths),
             code_url: self.code_url,
 
+            parse: self.parse,
+            format: self.format,
             export: self.export,
         }
     }

--- a/artifact-lib/src/lib.rs
+++ b/artifact-lib/src/lib.rs
@@ -369,6 +369,11 @@ pub struct Settings {
     pub code_url: Option<String>,
 
     // command specific settings
+    #[serde(default)]
+    pub parse: SettingsParse,
+    #[serde(default)]
+    pub format: SettingsFormat,
+    #[serde(default)]
     pub export: SettingsExport,
 }
 

--- a/artifact-ser/src/lib.rs
+++ b/artifact-ser/src/lib.rs
@@ -61,6 +61,23 @@ use crate::dev_prelude::*;
 
 // ------ SETTINGS ------
 
+/// Settings related to parsing artifacts.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SettingsParse {
+    /// How to parse the name in markdown
+    #[serde(default)]
+    pub md_name: SettingsMdName,
+}
+
+/// Settings related to formatting artifacts.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SettingsFormat {
+    /// How to write attributes.
+    #[serde(default)]
+    pub md_attrs: SettingsMdAttrs,
+}
+
+/// Settings related to exporting a project.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SettingsExport {
     #[serde(default)]
@@ -78,6 +95,11 @@ pub struct SettingsExport {
     /// How to handle formatting dot
     #[serde(default)]
     pub md_dot: SettingsMdDot,
+
+    /// How to write names
+    #[serde(default)]
+    pub md_name: SettingsMdName,
+
 }
 
 fn return_true() -> bool {
@@ -115,6 +137,65 @@ impl Default for SettingsMdDot {
         SettingsMdDot::Ignore
     }
 }
+
+/// Behavior when writing th ename markdown
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum SettingsMdName {
+    /// No special behavior
+    Default,
+
+    /// Prefix a value onto the name line.
+    ///
+    /// # Example
+    /// `value="#"` will write `## REQ-foo` instead of `# REQ-foo`
+    Prefix { value: String },
+}
+
+impl SettingsMdName {
+    pub fn to_prefix_string(&self) -> String {
+        match *self {
+            SettingsMdName::Default => "".to_string(),
+            SettingsMdName::Prefix { ref value } => value.clone(),
+        }
+    }
+}
+
+impl Default for SettingsMdName {
+    fn default() -> Self {
+        SettingsMdName::Default
+    }
+}
+
+/// Behavior when writing th ename markdown
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum SettingsMdAttrs {
+    /// Use hashes (default)
+    ///
+    /// # Example
+    ///
+    ///     # REQ-foo
+    ///     partof: something
+    ///     ###
+    Hashes,
+
+    /// Use a code block. It will always end in `art`.
+    ///
+    /// {Code: { prefix: Some("yaml") } would give:
+    ///
+    ///     ```yaml art
+    ///     partof: something
+    ///     ```
+    Code { prefix: Option<String> },
+}
+
+impl Default for SettingsMdAttrs {
+    fn default() -> Self {
+        SettingsMdAttrs::Hashes
+    }
+}
+
 
 // ------ HASH ------
 

--- a/artifact-ser/src/markdown.rs
+++ b/artifact-ser/src/markdown.rs
@@ -55,6 +55,7 @@ pub struct SerMarkdownSettings {
     pub code_url: Option<String>,
     pub family: SettingsMdFamily,
     pub dot: SettingsMdDot,
+    pub name_prefix: String,
 }
 
 impl<'a> SerMarkdown<'a> {
@@ -91,7 +92,7 @@ impl<'a> SerMarkdown<'a> {
     }
 
     fn to_markdown_toc(&self, w: &mut dyn io::Write) -> io::Result<()> {
-        write!(w, "# Table Of Contents\n")?;
+        write!(w, "{}# Table Of Contents\n", self.settings.name_prefix)?;
         for name in self.project.artifacts.keys() {
             write!(w, "- {}\n", self.name_markdown(name, None))?;
         }
@@ -106,7 +107,7 @@ impl<'a> SerMarkdown<'a> {
             }};
         }
 
-        write!(w, "# {0}\n", artifact.name)?;
+        write!(w, "{}# {}\n", self.settings.name_prefix, artifact.name)?;
         tag_details_begin(w, "metadata")?;
         self.art_to_markdown_family(w, artifact)?;
         write_html_line!("file", self.html_file_url(&artifact.file));
@@ -190,7 +191,7 @@ impl<'a> SerMarkdown<'a> {
             } else if let Some(name) = cap.name(NAME_RE_KEY) {
                 let sub = cap.name(NAME_SUB_RE_KEY).map(|s| subname!(s.as_str()));
                 self.name_markdown(&name!(name.as_str()), sub.as_ref())
-            } else if let Some(dot) = cap.name(DOT_RE_KEY) {
+            } else if cap.name(DOT_RE_KEY).is_some() {
                 self.replace_markdown_dot(parent, &cap)
             } else {
                 panic!("Got unknown match in md: {:?}", cap);

--- a/artifact-ser/src/ser.rs
+++ b/artifact-ser/src/ser.rs
@@ -18,7 +18,7 @@
 
 use crate::fmt;
 
-use super::{Completed, HashIm, SettingsExport};
+use super::{Completed, HashIm, SettingsExport, SettingsParse, SettingsFormat};
 use crate::dev_prelude::*;
 use crate::lint;
 use crate::name::{Name, SubName};
@@ -105,6 +105,10 @@ pub struct SettingsSer {
     pub code_url: Option<String>,
 
     // command specific settings
+    #[serde(default)]
+    pub parse: SettingsParse,
+    #[serde(default)]
+    pub format: SettingsFormat,
     #[serde(default)]
     pub export: SettingsExport,
 }

--- a/artifact-test/interop_tests/settings/.art/settings.toml
+++ b/artifact-test/interop_tests/settings/.art/settings.toml
@@ -1,0 +1,24 @@
+# artifact project settings
+
+# directories containing artifact toml files
+artifact_paths = ["{repo}/design"]
+
+# artifact paths to exclude. This is how you can avoid trying
+# to load .git/.hg/etc directories (or anything else you don't
+# want to include
+exclude_artifact_paths = []
+
+# directories containing code that has artifact links
+code_paths = ["/src", "/build.rs"]
+
+# directories to exclude when searching through code
+exclude_code_paths = []
+
+[parse]
+md_name = { type = "prefix", value = "#" }
+
+[format]
+md_attrs = {type = "code", prefix = "yaml"}
+
+[export]
+md_name = { type = "prefix", value = "#" }

--- a/artifact-test/interop_tests/settings/Cargo.lock
+++ b/artifact-test/interop_tests/settings/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "basic"
+version = "0.1.0"
+

--- a/artifact-test/interop_tests/settings/Cargo.toml
+++ b/artifact-test/interop_tests/settings/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "basic"
+version = "0.1.0"
+authors = ["Garrett Berg <googberg@gmail.com>"]
+
+[dependencies]

--- a/artifact-test/interop_tests/settings/assert-cases/basic/assert_load_lints.yaml
+++ b/artifact-test/interop_tests/settings/assert-cases/basic/assert_load_lints.yaml
@@ -1,0 +1,3 @@
+# no lints
+error: []
+other: []

--- a/artifact-test/interop_tests/settings/assert-cases/basic/assert_project.yaml
+++ b/artifact-test/interop_tests/settings/assert-cases/basic/assert_project.yaml
@@ -1,0 +1,253 @@
+# Basic project
+#
+# This contains a "sunny day" project with no errors for basic testing of
+# - loading artifact
+# - linking artifacts to source code
+settings:
+    code_paths:
+    - build.rs
+    - src
+
+    exclude_code_paths: []
+
+    artifact_paths:
+    - design
+
+    exclude_artifact_paths: []
+
+    parse:
+        md_name:
+            type: "prefix"
+            value: "#"
+
+    format:
+        md_attrs:
+            type: "code"
+            prefix: "yaml"
+
+
+    export:
+        md_name:
+            type: "prefix"
+            value: "#"
+
+code_impls:
+    REQ-baz:
+        primary:
+            file: src/baz.rs
+            line: 0
+        secondary: {}
+    SPC-build:
+        primary:
+            file: build.rs
+            line: 0
+        secondary:
+            .tst-unit:
+                file: build.rs
+                line: 5
+    SPC-foo:
+        primary:
+            file: src/foo/mod.rs
+            line: 0
+        secondary:
+            .yes:
+                file: src/foo/fab.rs
+                line: 3
+    TST-build:
+        primary:
+            file: build.rs
+            line: 4
+        secondary: {}
+    TST-foo:
+        primary: null
+        secondary:
+            .yes1:
+                file: src/foo/test.rs
+                line: 4
+            .yes2:
+                file: src/foo/test.rs
+                line: 6
+            .yes3:
+                file: src/foo/test.rs
+                line: 7
+            .yes4:
+                file: src/foo/fab.rs
+                line: 9
+
+artifacts:
+    REQ-purpose:
+        name: REQ-purpose
+        file: design/purpose.md
+        partof: []
+        parts:
+            - REQ-lib
+            - REQ-foo
+            - SPC-build
+            - TST-build
+        completed:
+            # (0<req-lib> + 0.875<req-foo> + 1.0<spc-build>) / 3
+            spc: 0.625
+            # (0<req-lib> + 0.893<req-foo> + 0.75<spc-build> + 0.5<tst-build>) / 4
+            tst: 0.536
+        text: |
+            The purpose of this project is is to test a basic
+            project... that's it!
+        impl_: null
+        subnames: []
+    REQ-lib:
+        name: REQ-lib
+        file: design/purpose.md
+        partof:
+            - REQ-purpose
+        parts: []
+        completed: {spc: 0.0, tst: 0.0}
+        text: |-
+            Lib is definitely a library
+        impl_: null
+        subnames: []
+    REQ-foo:
+        name: REQ-foo
+        file: design/purpose.md
+        partof:
+            - REQ-purpose
+        parts:
+            - SPC-foo
+            - SPC-foo_done
+        completed:
+            spc: 0.875 # (1.0<foo_done> + 0.75) / 2
+            tst: 0.893 # (1.0<foo_done> + 0.786) / 2
+        text: |-
+            foo needs to do the foo thing
+        impl_: null
+        subnames: []
+    REQ-baz:
+        name: REQ-baz
+        file: design/purpose.md
+        partof: []
+        parts: []
+        completed: {spc: 1.0, tst: 0.0}
+        text: |
+            implemented directly in source!
+
+            Not a partof anything...
+        impl_:
+            primary:
+                file: src/baz.rs
+                line: 0
+            secondary: {}
+        subnames: []
+    SPC-build:
+        name: SPC-build
+        file: design/purpose.md
+        partof:
+            - REQ-purpose
+        parts:
+            - TST-build
+        completed: {spc: 1.0, tst: 0.75}
+        text: "This has a build file.\n\nUnit tests:\n- [[.tst-unit]]\n"
+        impl_:
+            primary:
+                file: build.rs
+                line: 0
+            secondary:
+                .tst-unit:
+                    file: build.rs
+                    line: 5
+        subnames: [".tst-unit"]
+    TST-build:
+        name: TST-build
+        file: design/purpose.md
+        partof:
+            - REQ-purpose
+            - SPC-build
+        parts: []
+        completed: {spc: 0.5, tst: 0.5}
+        text: |
+            direct link to REQ-purpose
+
+            - [[.no]]
+        impl_:
+            primary:
+                file: build.rs
+                line: 4
+            secondary: {}
+        subnames:
+            - .no
+    SPC-foo:
+        name: SPC-foo
+        file: design/foo.md
+        partof:
+            - REQ-foo
+        parts:
+            - SPC-foo_done
+            - TST-foo
+        completed:
+            spc: 0.75 # (1.0<foo_done> + 1.0<self> + 1.0<self.yes>) / 4
+            tst: 0.786 # (1.0<foo_done> + 0.571<TST-foo>) / 2
+        text: |
+            This is the spec for foo, it does lots of foo.
+
+            It is some foo subparts:
+            - [[.no]]: not done
+            - [[.yes]]: done
+        impl_:
+            primary:
+                file: src/foo/mod.rs
+                line: 0
+            secondary:
+                .yes:
+                    file: src/foo/fab.rs
+                    line: 3
+        subnames:
+            - .no
+            - .yes
+    SPC-foo_done:
+        name: SPC-foo_done
+        file: design/foo.md
+        partof:
+            - REQ-foo
+            - SPC-foo
+        parts: []
+        completed: {spc: 1.0, tst: 1.0}
+        text: |-
+            This is done and is weird?
+        impl_: this is done
+        subnames: []
+    TST-foo:
+        name: TST-foo
+        file: design/foo.md
+        partof:
+            - SPC-foo
+        parts: []
+        completed: {spc: 0.571, tst: 0.571} # 4<done> / (1<self> + 4<yes> + 2<no>)
+        text: |
+            Partially done foo test with some subparts
+
+            - [[.no1]]
+            - [[.no2]]
+            - [[.yes1]]
+            - [[.yes2]]
+            - [[.yes3]]
+            - [[.yes4]]
+        impl_:
+            primary: null
+            secondary:
+                .yes1:
+                    file: src/foo/test.rs
+                    line: 4
+                .yes2:
+                    file: src/foo/test.rs
+                    line: 6
+                .yes3:
+                    file: src/foo/test.rs
+                    line: 7
+                .yes4:
+                    file: src/foo/fab.rs
+                    line: 9
+        subnames:
+            - .no1
+            - .no2
+            - .yes1
+            - .yes2
+            - .yes3
+            - .yes4

--- a/artifact-test/interop_tests/settings/assert-cases/basic/assert_project_lints.yaml
+++ b/artifact-test/interop_tests/settings/assert-cases/basic/assert_project_lints.yaml
@@ -1,0 +1,2 @@
+error: []
+other: []

--- a/artifact-test/interop_tests/settings/build.rs
+++ b/artifact-test/interop_tests/settings/build.rs
@@ -1,0 +1,6 @@
+//! #SPC-build
+//!
+//! Build file, included by direct path
+
+// And some test: #TST-build (but not subpart)
+// Also a unit test: #SPC-build.tst-unit

--- a/artifact-test/interop_tests/settings/design/foo.md
+++ b/artifact-test/interop_tests/settings/design/foo.md
@@ -1,0 +1,28 @@
+## SPC-foo
+This is the spec for foo, it does lots of foo.
+
+It is some foo subparts:
+- [[.no]]: not done
+- [[.yes]]: done
+
+
+## SPC-foo_done
+```yaml art
+done: this is done
+
+partof:
+- REQ-foo
+- SPC-foo
+```
+This is done and is weird?
+
+
+## TST-foo
+Partially done foo test with some subparts
+
+- [[.no1]]
+- [[.no2]]
+- [[.yes1]]
+- [[.yes2]]
+- [[.yes3]]
+- [[.yes4]]

--- a/artifact-test/interop_tests/settings/design/purpose.md
+++ b/artifact-test/interop_tests/settings/design/purpose.md
@@ -1,0 +1,42 @@
+## REQ-baz
+implemented directly in source!
+
+Not a partof anything...
+
+
+## REQ-foo
+```yaml art
+partof: REQ-purpose
+```
+foo needs to do the foo thing
+
+
+## REQ-lib
+```yaml art
+partof: REQ-purpose
+```
+Lib is definitely a library
+
+
+## REQ-purpose
+The purpose of this project is is to test a basic
+project... that's it!
+
+
+## SPC-build
+```yaml art
+partof: REQ-purpose
+```
+This has a build file.
+
+Unit tests:
+- [[.tst-unit]]
+
+
+## TST-build
+```yaml art
+partof: REQ-purpose
+```
+direct link to REQ-purpose
+
+- [[.no]]

--- a/artifact-test/interop_tests/settings/exported.md
+++ b/artifact-test/interop_tests/settings/exported.md
@@ -1,0 +1,172 @@
+## Table Of Contents
+- <a style="font-weight: bold; color: #0074D9" title="REQ-BAZ" href="#REQ-BAZ">REQ-baz</a>
+- <a style="font-weight: bold; color: #0074D9" title="REQ-FOO" href="#REQ-FOO">REQ-foo</a>
+- <a style="font-weight: bold; color: #FF4136" title="REQ-LIB" href="#REQ-LIB">REQ-lib</a>
+- <a style="font-weight: bold; color: #FF851B" title="REQ-PURPOSE" href="#REQ-PURPOSE">REQ-purpose</a>
+- <a style="font-weight: bold; color: #0074D9" title="SPC-BUILD" href="#SPC-BUILD">SPC-build</a>
+- <a style="font-weight: bold; color: #0074D9" title="SPC-FOO" href="#SPC-FOO">SPC-foo</a>
+- <a style="font-weight: bold; color: #3DA03D" title="SPC-FOO_DONE" href="#SPC-FOO_DONE">SPC-foo_done</a>
+- <a style="font-weight: bold; color: #FF851B" title="TST-BUILD" href="#TST-BUILD">TST-build</a>
+- <a style="font-weight: bold; color: #FF851B" title="TST-FOO" href="#TST-FOO">TST-foo</a>
+
+
+## REQ-baz
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b> <i>none</i></a><br>
+<b>parts:</b> <i>none</i></a><br>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> src/baz.rs[0]<br>
+<b>spc:</b>100.00&nbsp;&nbsp;<b>tst:</b>0.00<br>
+<hr>
+</details>
+
+implemented directly in source!
+
+Not a partof anything...
+
+
+## REQ-foo
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #FF851B" title="REQ-PURPOSE" href="#REQ-PURPOSE">REQ-purpose</a></li>
+<b>parts:</b><br>
+<li><a style="font-weight: bold; color: #0074D9" title="SPC-FOO" href="#SPC-FOO">SPC-foo</a></li>
+<li><a style="font-weight: bold; color: #3DA03D" title="SPC-FOO_DONE" href="#SPC-FOO_DONE">SPC-foo_done</a></li>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> <i>not implemented</i><br>
+<b>spc:</b>87.50&nbsp;&nbsp;<b>tst:</b>89.30<br>
+<hr>
+</details>
+
+foo needs to do the foo thing
+
+## REQ-lib
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #FF851B" title="REQ-PURPOSE" href="#REQ-PURPOSE">REQ-purpose</a></li>
+<b>parts:</b> <i>none</i></a><br>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> <i>not implemented</i><br>
+<b>spc:</b>0.00&nbsp;&nbsp;<b>tst:</b>0.00<br>
+<hr>
+</details>
+
+Lib is definitely a library
+
+## REQ-purpose
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b> <i>none</i></a><br>
+<b>parts:</b><br>
+<li><a style="font-weight: bold; color: #0074D9" title="REQ-FOO" href="#REQ-FOO">REQ-foo</a></li>
+<li><a style="font-weight: bold; color: #FF4136" title="REQ-LIB" href="#REQ-LIB">REQ-lib</a></li>
+<li><a style="font-weight: bold; color: #0074D9" title="SPC-BUILD" href="#SPC-BUILD">SPC-build</a></li>
+<li><a style="font-weight: bold; color: #FF851B" title="TST-BUILD" href="#TST-BUILD">TST-build</a></li>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> <i>not implemented</i><br>
+<b>spc:</b>62.50&nbsp;&nbsp;<b>tst:</b>53.60<br>
+<hr>
+</details>
+
+The purpose of this project is is to test a basic
+project... that's it!
+
+
+## SPC-build
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #FF851B" title="REQ-PURPOSE" href="#REQ-PURPOSE">REQ-purpose</a></li>
+<b>parts:</b><br>
+<li><a style="font-weight: bold; color: #FF851B" title="TST-BUILD" href="#TST-BUILD">TST-build</a></li>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> build.rs[0]<br>
+<b>spc:</b>100.00&nbsp;&nbsp;<b>tst:</b>75.00<br>
+<hr>
+</details>
+
+This has a build file.
+
+Unit tests:
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/build.rs[5]" style="color: #0074D9"><b><i>.tst-unit</i></b></span>
+
+
+## SPC-foo
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #0074D9" title="REQ-FOO" href="#REQ-FOO">REQ-foo</a></li>
+<b>parts:</b><br>
+<li><a style="font-weight: bold; color: #3DA03D" title="SPC-FOO_DONE" href="#SPC-FOO_DONE">SPC-foo_done</a></li>
+<li><a style="font-weight: bold; color: #FF851B" title="TST-FOO" href="#TST-FOO">TST-foo</a></li>
+<b>file:</b> design/foo.md<br>
+<b>impl:</b> src/foo/mod.rs[0]<br>
+<b>spc:</b>75.00&nbsp;&nbsp;<b>tst:</b>78.60<br>
+<hr>
+</details>
+
+This is the spec for foo, it does lots of foo.
+
+It is some foo subparts:
+- <span title="Not Implemented" style="color: #FF4136"><b><i>.no</i></b></span>: not done
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/src/foo/fab.rs[3]" style="color: #0074D9"><b><i>.yes</i></b></span>: done
+
+
+## SPC-foo_done
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #0074D9" title="REQ-FOO" href="#REQ-FOO">REQ-foo</a></li>
+<li><a style="font-weight: bold; color: #0074D9" title="SPC-FOO" href="#SPC-FOO">SPC-foo</a></li>
+<b>parts:</b> <i>none</i></a><br>
+<b>file:</b> design/foo.md<br>
+<b>impl:</b> this is done<br>
+<b>spc:</b>100.00&nbsp;&nbsp;<b>tst:</b>100.00<br>
+<hr>
+</details>
+
+This is done and is weird?
+
+## TST-build
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #FF851B" title="REQ-PURPOSE" href="#REQ-PURPOSE">REQ-purpose</a></li>
+<li><a style="font-weight: bold; color: #0074D9" title="SPC-BUILD" href="#SPC-BUILD">SPC-build</a></li>
+<b>parts:</b> <i>none</i></a><br>
+<b>file:</b> design/purpose.md<br>
+<b>impl:</b> build.rs[4]<br>
+<b>spc:</b>50.00&nbsp;&nbsp;<b>tst:</b>50.00<br>
+<hr>
+</details>
+
+direct link to REQ-purpose
+
+- <span title="Not Implemented" style="color: #FF4136"><b><i>.no</i></b></span>
+
+
+## TST-foo
+<details>
+<summary><b>metadata</b></summary>
+<b>partof:</b><br>
+<li><a style="font-weight: bold; color: #0074D9" title="SPC-FOO" href="#SPC-FOO">SPC-foo</a></li>
+<b>parts:</b> <i>none</i></a><br>
+<b>file:</b> design/foo.md<br>
+<b>impl:</b> <i>not implemented</i><br>
+<b>spc:</b>57.10&nbsp;&nbsp;<b>tst:</b>57.10<br>
+<hr>
+</details>
+
+Partially done foo test with some subparts
+
+- <span title="Not Implemented" style="color: #FF4136"><b><i>.no1</i></b></span>
+- <span title="Not Implemented" style="color: #FF4136"><b><i>.no2</i></b></span>
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/src/foo/test.rs[4]" style="color: #0074D9"><b><i>.yes1</i></b></span>
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/src/foo/test.rs[6]" style="color: #0074D9"><b><i>.yes2</i></b></span>
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/src/foo/test.rs[7]" style="color: #0074D9"><b><i>.yes3</i></b></span>
+- <span title="/home/rett/open/artifact/artifact-test/interop_tests/settings/src/foo/fab.rs[9]" style="color: #0074D9"><b><i>.yes4</i></b></span>
+
+

--- a/artifact-test/interop_tests/settings/src/baz.rs
+++ b/artifact-test/interop_tests/settings/src/baz.rs
@@ -1,0 +1,2 @@
+/// #REQ-baz
+/// Just implement baz directly

--- a/artifact-test/interop_tests/settings/src/foo/fab.rs
+++ b/artifact-test/interop_tests/settings/src/foo/fab.rs
@@ -1,0 +1,13 @@
+//! This has foo stuff
+
+
+/// #SPC-foo.yes
+/// Do foo?
+fn foo() {
+}
+
+#[test]
+/// #TST-foo.yes4
+fn test_samefile() {
+    println!("TST-foo");  // nothing happens without `#`
+}

--- a/artifact-test/interop_tests/settings/src/foo/mod.rs
+++ b/artifact-test/interop_tests/settings/src/foo/mod.rs
@@ -1,0 +1,3 @@
+/// #SPC-foo
+///
+/// This is where foo is implemented

--- a/artifact-test/interop_tests/settings/src/foo/test.rs
+++ b/artifact-test/interop_tests/settings/src/foo/test.rs
@@ -1,0 +1,9 @@
+/// Test foo and stuff. Don't link TST-foo directly
+
+
+#[test]
+/// #TST-foo.yes1
+fn foo_1() {
+    // #TST-foo.yes2
+    // #TST-foo.yes3
+}

--- a/artifact-test/interop_tests/settings/src/lib.rs
+++ b/artifact-test/interop_tests/settings/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/artifact-test/src/dev_prelude.rs
+++ b/artifact-test/src/dev_prelude.rs
@@ -146,7 +146,10 @@ pub fn to_json_string<T: Serialize>(value: &T) -> String {
 }
 
 pub fn from_markdown_str(s: &str) -> StrResult<IndexMap<Name, artifact_data::raw::ArtifactRaw>> {
-    artifact_data::raw::from_markdown(s.as_bytes()).map_err(|e| e.to_string())
+    let parser = artifact_data::raw::Parser::new();
+    parser
+        .from_markdown(s.as_bytes())
+        .map_err(|e| e.to_string())
 }
 
 /// Do a serialization/deserialization roundtrip assertion.

--- a/artifact-test/src/raw.rs
+++ b/artifact-test/src/raw.rs
@@ -21,9 +21,7 @@
 use super::dev_prelude::*;
 use super::family::{arb_topologically_sorted_names, rand_select_partof};
 use super::implemented::random_impl_links;
-use artifact_data::raw::{
-    from_markdown, to_markdown, ArtifactRaw, TextRaw, ATTRS_END_RE, NAME_LINE_RE,
-};
+use artifact_data::raw::{Formatter, ArtifactRaw, Parser, TextRaw, ATTRS_END_RE};
 use artifact_data::raw_names::NamesRaw;
 
 // ------------------------------
@@ -50,11 +48,12 @@ pub fn lines_to_text_raw<R: Rng + Clone>(
         );
     }
 
+    let parser = Parser::new();
     // TODO: add link references
     let mut text: String = lines
         .iter()
         .map(|l| l.join(" "))
-        .filter(|l| !(NAME_LINE_RE.is_match(l) || ATTRS_END_RE.is_match(l)))
+        .filter(|l| !(parser.md_name_line_re.is_match(l) || ATTRS_END_RE.is_match(l)))
         .join("\n");
 
     string_trim_right(&mut text);

--- a/justfile
+++ b/justfile
@@ -2,13 +2,13 @@ build-frontend:
 	cargo-web deploy -p artifact-frontend --release --target=wasm32-unknown-unknown
 
 check: build-frontend
-	cargo check -p artifact-app
+	cargo check -p artifact-app -j$(( $(nproc) * 3))
 
 build: build-frontend
-	cargo build -p artifact-app
+	cargo build -p artifact-app -j$(( $(nproc) * 3))
 
 build-release: build-frontend
-	cargo build -p artifact-app --release
+	cargo build -p artifact-app --release -j$(( $(nproc) * 3))
 
 test: build-frontend
-	cargo test -p artifact-app
+	cargo test -p artifact-app -j$(( $(nproc) * 3))


### PR DESCRIPTION
These add flags to make the various steps within artifact much
more configurable to account for different "flavors" of markdown,
along with style preferences for teams.

- add ability to configure md names
- add the ability to have prefixes to names in markdown (parse+fmt and
  export)
- add the ability to use code blocks instead of `###` for attributes

Although these features will be going into the binary, they should
be considered **unstable until they are fully documented**.